### PR TITLE
Make remote tap url configurable

### DIFF
--- a/lib/tails/remotetapclient.ex
+++ b/lib/tails/remotetapclient.ex
@@ -6,8 +6,7 @@ defmodule Tails.RemoteTapClient do
       {"Origin", "http://localhost"}
     ]
 
-    url = "ws://localhost:12001"
-    # IO.puts("starting link!!!")
+    url = System.get_env("REMOTE_TAP_ENDPOINT") || "ws://localhost:12001"
 
     WebSockex.start_link(url, __MODULE__, state,
       insecure: true,


### PR DESCRIPTION
makes the remotetap url configurable through `REMOTE_TAP_ENDPOINT` env var.

closes #15 